### PR TITLE
Adiciona flag --build para atualizar os containers

### DIFF
--- a/bin/rolling-update.sh
+++ b/bin/rolling-update.sh
@@ -4,10 +4,10 @@ echo "Starting rolling update"
 docker ps --format "table {{.ID}} {{.Names}} {{.CreatedAt}}"
 
 git pull origin master \
-    && docker-compose -f docker-compose.production.yaml up -d --remove-orphans --no-deps --scale api=2 --no-recreate api \
+    && docker-compose -f docker-compose.production.yaml up -d --build --remove-orphans --no-deps --scale api=2 --no-recreate api \
     && docker-compose -f docker-compose.production.yaml exec nginx nginx -s reload \
     && docker kill -s SIGTERM $PREVIOUS_CONTAINER \
-    && docker-compose -f docker-compose.production.yaml up -d --remove-orphans --no-deps --scale api=1 --no-recreate api
+    && docker-compose -f docker-compose.production.yaml up -d --build --remove-orphans --no-deps --scale api=1 --no-recreate api
 
 echo "Rolling update done"
 docker ps --format "table {{.ID}} {{.Names}} {{.CreatedAt}}"


### PR DESCRIPTION
Precisamos fazer o build dos containers após um novo deploy. Isso é necessário pois se uma nova dependência for adicionada, ela será instalada no momento de build dos containers evitando erros na aplicação.